### PR TITLE
Add inline edit form for posting details

### DIFF
--- a/backend/app/routers/postings.py
+++ b/backend/app/routers/postings.py
@@ -109,11 +109,19 @@ def update_posting(posting_id: int, data: JobPostingUpdate, db: Session = Depend
     posting = db.get(JobPosting, posting_id)
     if not posting:
         raise HTTPException(status_code=404, detail="Posting not found")
-    for key, value in data.model_dump(exclude_unset=True).items():
+    update_dict = data.model_dump(exclude_unset=True)
+    company_name = update_dict.pop("company_name", None)
+    if company_name is not None:
+        posting.company_id = _get_or_create_company(db, company_name).id
+    for key, value in update_dict.items():
         setattr(posting, key, value)
     db.commit()
-    db.refresh(posting)
-    return posting
+    posting = db.query(JobPosting).options(
+        joinedload(JobPosting.company), joinedload(JobPosting.pipeline_entry)
+    ).filter(JobPosting.id == posting_id).first()
+    result = JobPostingRead.model_validate(posting)
+    result.pipeline_stage = posting.pipeline_entry.stage if posting.pipeline_entry else None
+    return result
 
 
 @router.post("/{posting_id}/save", response_model=JobPostingRead)

--- a/backend/app/schemas/job_posting.py
+++ b/backend/app/schemas/job_posting.py
@@ -18,6 +18,7 @@ class JobPostingCreate(BaseModel):
 
 class JobPostingUpdate(BaseModel):
     title: str | None = None
+    company_name: str | None = None
     description: str | None = None
     location: str | None = None
     remote_type: str | None = None

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -53,7 +53,7 @@ export const postings = {
   dismiss: (id: number) => request<JobPosting>(`/postings/${id}/dismiss`, { method: 'POST' }),
   create: (data: Partial<JobPosting> & { company_name?: string }) =>
     request<JobPosting>('/postings', { method: 'POST', body: JSON.stringify(data) }),
-  update: (id: number, data: Partial<JobPosting>) =>
+  update: (id: number, data: Partial<JobPosting> & { company_name?: string }) =>
     request<JobPosting>(`/postings/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   delete: (id: number) => request<void>(`/postings/${id}`, { method: 'DELETE' }),
   importPreview: (data: { text?: string; url?: string }) =>

--- a/frontend/src/lib/components/PostingDetailPanel.svelte
+++ b/frontend/src/lib/components/PostingDetailPanel.svelte
@@ -22,6 +22,61 @@
 	let addingToPipeline = $state(false);
 	let status = $state('');
 
+	let localPosting = $state({ ...posting });
+	$effect(() => { localPosting = { ...posting }; });
+
+	let editing = $state(false);
+	let saving = $state(false);
+	let editTitle = $state('');
+	let editCompany = $state('');
+	let editLocation = $state('');
+	let editRemoteType = $state('');
+	let editSalaryMin = $state<number | undefined>(undefined);
+	let editSalaryMax = $state<number | undefined>(undefined);
+	let editUrl = $state('');
+	let editDescription = $state('');
+
+	function handleEditStart() {
+		editTitle = localPosting.title;
+		editCompany = localPosting.company?.name ?? '';
+		editLocation = localPosting.location ?? '';
+		editRemoteType = localPosting.remote_type ?? '';
+		editSalaryMin = localPosting.salary_min ?? undefined;
+		editSalaryMax = localPosting.salary_max ?? undefined;
+		editUrl = localPosting.url ?? '';
+		editDescription = localPosting.description ?? '';
+		editing = true;
+	}
+
+	function handleCancel() {
+		editing = false;
+		status = '';
+	}
+
+	async function handleSave() {
+		saving = true;
+		status = '';
+		try {
+			const updated = await postings.update(localPosting.id, {
+				title: editTitle,
+				company_name: editCompany || undefined,
+				location: editLocation || undefined,
+				remote_type: editRemoteType || undefined,
+				salary_min: editSalaryMin ?? null,
+				salary_max: editSalaryMax ?? null,
+				url: editUrl || undefined,
+				description: editDescription || undefined,
+			});
+			localPosting = updated;
+			editing = false;
+			onUpdated();
+		} catch (e) {
+			status = e instanceof Error ? e.message : 'Save failed';
+		} finally {
+			saving = false;
+		}
+	}
+
 	function formatSalary(min: number | null, max: number | null): string {
 		if (!min && !max) return 'Not specified';
 		const fmt = (n: number) => '$' + n.toLocaleString();
@@ -62,81 +117,141 @@
 	<div class="panel" onclick={(e) => e.stopPropagation()}>
 		<div class="panel-header">
 			<div class="panel-title-block">
-				<h2>{posting.title}</h2>
-				{#if posting.company}
-					<span class="company-name">{posting.company.name}</span>
+				<h2>{localPosting.title}</h2>
+				{#if localPosting.company}
+					<span class="company-name">{localPosting.company.name}</span>
 				{/if}
 			</div>
-			<button class="close-btn" onclick={onClose}>✕</button>
+			<div class="panel-header-actions">
+				{#if !editing}
+					<button class="btn btn-sm btn-secondary" onclick={handleEditStart}>Edit</button>
+				{/if}
+				<button class="close-btn" onclick={onClose}>✕</button>
+			</div>
 		</div>
 
-		<div class="panel-meta">
-			{#if posting.location}
-				<span class="meta-item">📍 {posting.location}</span>
-			{/if}
-			{#if posting.remote_type}
-				<span class="badge badge-stage">{posting.remote_type}</span>
-			{/if}
-			<span class="meta-item">💰 {formatSalary(posting.salary_min, posting.salary_max)}</span>
-			<span class="meta-item">🔗 {posting.source}</span>
-			{#if posting.pipeline_stage}
-				<span class="badge badge-stage">{posting.pipeline_stage}</span>
-			{/if}
-		</div>
+		{#if editing}
+			<div class="edit-form">
+				<div class="form-group">
+					<label>Title</label>
+					<input type="text" bind:value={editTitle} style="width: 100%" />
+				</div>
+				<div class="form-row">
+					<div class="form-group">
+						<label>Company</label>
+						<input type="text" bind:value={editCompany} style="width: 100%" />
+					</div>
+					<div class="form-group">
+						<label>Location</label>
+						<input type="text" bind:value={editLocation} style="width: 100%" />
+					</div>
+				</div>
+				<div class="form-row">
+					<div class="form-group">
+						<label>Remote</label>
+						<select bind:value={editRemoteType} style="width: 100%">
+							<option value="">Unknown</option>
+							<option value="remote">Remote</option>
+							<option value="hybrid">Hybrid</option>
+							<option value="onsite">Onsite</option>
+						</select>
+					</div>
+					<div class="form-group">
+						<label>Min Salary</label>
+						<input type="number" bind:value={editSalaryMin} style="width: 100%" />
+					</div>
+					<div class="form-group">
+						<label>Max Salary</label>
+						<input type="number" bind:value={editSalaryMax} style="width: 100%" />
+					</div>
+				</div>
+				<div class="form-group">
+					<label>URL</label>
+					<input type="url" bind:value={editUrl} style="width: 100%" />
+				</div>
+				<div class="form-group">
+					<label>Description</label>
+					<textarea bind:value={editDescription} rows={8} style="width: 100%"></textarea>
+				</div>
+				{#if status}
+					<p class="status-msg error">{status}</p>
+				{/if}
+				<div class="panel-actions">
+					<button class="btn btn-primary" onclick={handleSave} disabled={saving || !editTitle}>
+						{saving ? 'Saving...' : 'Save'}
+					</button>
+					<button class="btn btn-secondary" onclick={handleCancel}>Cancel</button>
+				</div>
+			</div>
+		{:else}
+			<div class="panel-meta">
+				{#if localPosting.location}
+					<span class="meta-item">📍 {localPosting.location}</span>
+				{/if}
+				{#if localPosting.remote_type}
+					<span class="badge badge-stage">{localPosting.remote_type}</span>
+				{/if}
+				<span class="meta-item">💰 {formatSalary(localPosting.salary_min, localPosting.salary_max)}</span>
+				<span class="meta-item">🔗 {localPosting.source}</span>
+				{#if localPosting.pipeline_stage}
+					<span class="badge badge-stage">{localPosting.pipeline_stage}</span>
+				{/if}
+			</div>
 
-		{#if posting.url}
-			<a href={posting.url} target="_blank" rel="noopener" class="view-link">View Original Posting ↗</a>
-		{/if}
+			{#if localPosting.url}
+				<a href={localPosting.url} target="_blank" rel="noopener" class="view-link">View Original Posting ↗</a>
+			{/if}
 
-		{#if posting.company}
-			<div class="section">
-				<h3>Company</h3>
-				<div class="company-links">
-					{#if posting.company.website}
-						<a href={posting.company.website} target="_blank" rel="noopener" class="btn btn-sm btn-secondary">Website ↗</a>
-					{/if}
-					{#if posting.company.glassdoor_url}
-						<a href={posting.company.glassdoor_url} target="_blank" rel="noopener" class="btn btn-sm btn-secondary">
-							Glassdoor {posting.company.glassdoor_rating ? `(${posting.company.glassdoor_rating}★)` : '↗'}
-						</a>
-					{/if}
-					{#if posting.company.levels_url}
-						<a href={posting.company.levels_url} target="_blank" rel="noopener" class="btn btn-sm btn-secondary">Levels.fyi ↗</a>
-					{/if}
-					{#if posting.company.blind_url}
-						<a href={posting.company.blind_url} target="_blank" rel="noopener" class="btn btn-sm btn-secondary">Blind ↗</a>
+			{#if localPosting.company}
+				<div class="section">
+					<h3>Company</h3>
+					<div class="company-links">
+						{#if localPosting.company.website}
+							<a href={localPosting.company.website} target="_blank" rel="noopener" class="btn btn-sm btn-secondary">Website ↗</a>
+						{/if}
+						{#if localPosting.company.glassdoor_url}
+							<a href={localPosting.company.glassdoor_url} target="_blank" rel="noopener" class="btn btn-sm btn-secondary">
+								Glassdoor {localPosting.company.glassdoor_rating ? `(${localPosting.company.glassdoor_rating}★)` : '↗'}
+							</a>
+						{/if}
+						{#if localPosting.company.levels_url}
+							<a href={localPosting.company.levels_url} target="_blank" rel="noopener" class="btn btn-sm btn-secondary">Levels.fyi ↗</a>
+						{/if}
+						{#if localPosting.company.blind_url}
+							<a href={localPosting.company.blind_url} target="_blank" rel="noopener" class="btn btn-sm btn-secondary">Blind ↗</a>
+						{/if}
+					</div>
+					{#if localPosting.company.industry || localPosting.company.employee_count}
+						<p class="company-detail">
+							{#if localPosting.company.industry}{localPosting.company.industry}{/if}
+							{#if localPosting.company.employee_count} · {localPosting.company.employee_count.toLocaleString()} employees{/if}
+						</p>
 					{/if}
 				</div>
-				{#if posting.company.industry || posting.company.employee_count}
-					<p class="company-detail">
-						{#if posting.company.industry}{posting.company.industry}{/if}
-						{#if posting.company.employee_count} · {posting.company.employee_count.toLocaleString()} employees{/if}
-					</p>
-				{/if}
-			</div>
-		{/if}
-
-		{#if posting.description}
-			<div class="section">
-				<h3>Description</h3>
-				<div class="description-text">{@html renderMarkdown(posting.description)}</div>
-			</div>
-		{/if}
-
-		{#if status}
-			<p class="status-msg">{status}</p>
-		{/if}
-
-		<div class="panel-actions">
-			{#if !posting.pipeline_stage}
-				<button class="btn btn-primary" onclick={handleAddToPipeline} disabled={addingToPipeline}>
-					{addingToPipeline ? 'Adding...' : '+ Add to Pipeline'}
-				</button>
 			{/if}
-			<button class="btn btn-danger" onclick={handleDelete} disabled={deleting}>
-				{deleting ? 'Deleting...' : 'Delete'}
-			</button>
-		</div>
+
+			{#if localPosting.description}
+				<div class="section">
+					<h3>Description</h3>
+					<div class="description-text">{@html renderMarkdown(localPosting.description)}</div>
+				</div>
+			{/if}
+
+			{#if status}
+				<p class="status-msg">{status}</p>
+			{/if}
+
+			<div class="panel-actions">
+				{#if !localPosting.pipeline_stage}
+					<button class="btn btn-primary" onclick={handleAddToPipeline} disabled={addingToPipeline}>
+						{addingToPipeline ? 'Adding...' : '+ Add to Pipeline'}
+					</button>
+				{/if}
+				<button class="btn btn-danger" onclick={handleDelete} disabled={deleting}>
+					{deleting ? 'Deleting...' : 'Delete'}
+				</button>
+			</div>
+		{/if}
 	</div>
 </div>
 
@@ -168,6 +283,43 @@
 		align-items: flex-start;
 		justify-content: space-between;
 		gap: 1rem;
+	}
+
+	.panel-header-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-shrink: 0;
+	}
+
+	.edit-form {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+	}
+
+	.form-group {
+		margin-bottom: 0.75rem;
+	}
+
+	.form-group label {
+		display: block;
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+		margin-bottom: 0.25rem;
+	}
+
+	.form-row {
+		display: flex;
+		gap: 0.75rem;
+	}
+
+	.form-row .form-group {
+		flex: 1;
+	}
+
+	.status-msg.error {
+		color: var(--accent-red);
 	}
 
 	.panel-title-block h2 {


### PR DESCRIPTION
## Summary
Users can now edit any posting field directly from the detail panel. Click the "Edit" button to modify title, company name, location, remote type, salary range, URL, or description. Changes save to the database with a single request.

## Changes
- **Backend**: `JobPostingUpdate` schema now accepts `company_name` parameter. Update endpoint handles company lookup/creation and returns complete company + pipeline data.
- **Frontend**: Edit toggle in `PostingDetailPanel` with inline form matching existing `ImportModal` styling. Form fields sync back to panel immediately after save.

## Testing
1. Open a saved posting → Click Edit
2. Change any field (especially company name) → Click Save
3. Verify changes persist across panel close/reopen
4. Test creating new company by editing to a name that doesn't exist yet