### PR TITLE
Style company links as normal text with hover underline

### DIFF
--- a/frontend/src/routes/postings/+page.svelte
+++ b/frontend/src/routes/postings/+page.svelte
@@ -291,15 +291,15 @@
 		background: none;
 		border: none;
 		padding: 0;
-		color: var(--accent-blue);
+		color: inherit;
 		cursor: pointer;
 		font-size: inherit;
 		font-family: inherit;
-		text-decoration: underline;
+		text-decoration: none;
 	}
 
 	.company-link:hover {
-		opacity: 0.8;
+		text-decoration: underline;
 	}
 
 	.sortable {


### PR DESCRIPTION
Make company names in the postings table appear as normal text instead of blue underlined links. Underline appears on hover to indicate interactivity.

This provides a cleaner look while maintaining the interactive functionality of clicking to open company details.