### PR TITLE
fix: allow clearing optional fields when editing postings

### DIFF
--- a/frontend/src/lib/components/PostingDetailPanel.svelte
+++ b/frontend/src/lib/components/PostingDetailPanel.svelte
@@ -60,13 +60,13 @@
 		try {
 			const updated = await postings.update(localPosting.id, {
 				title: editTitle,
-				company_name: editCompany || undefined,
-				location: editLocation || undefined,
-				remote_type: editRemoteType || undefined,
+				company_name: editCompany || null,
+				location: editLocation || null,
+				remote_type: editRemoteType || null,
 				salary_min: editSalaryMin ?? null,
 				salary_max: editSalaryMax ?? null,
-				url: editUrl || undefined,
-				description: editDescription || undefined,
+				url: editUrl || null,
+				description: editDescription || null,
 			});
 			localPosting = updated;
 			editing = false;


### PR DESCRIPTION
When clearing optional string fields (location, company_name, remote_type, url, description) in the posting edit form, the frontend was sending `undefined` instead of `null`. Since `undefined` is omitted from JSON serialization, the backend never received those fields and the old values were preserved. This fix sends `null` for empty string fields so the backend properly clears them.