### PR TITLE
fix: prevent UNIQUE constraint violations in search

### DIFF
--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -74,6 +74,19 @@ def run_search(profile: SearchProfile, db: Session) -> dict:
             db.add(company)
             db.flush()
 
+        # Re-check with resolved company.id — the earlier check may have been skipped
+        # if the company didn't exist yet (e.g. first time seeing this company in this run)
+        existing = db.query(JobPosting).filter(
+            JobPosting.title == title, JobPosting.company_id == company.id
+        ).first()
+        if existing:
+            if existing.status not in ('saved', 'dismissed'):
+                result = SearchResult(
+                    search_profile_id=profile.id, job_posting_id=existing.id, is_new=False
+                )
+                db.add(result)
+            continue
+
         remote_type = "remote" if row.get("is_remote") else None
         posting = JobPosting(
             title=title,


### PR DESCRIPTION
When running a search, `run_search()` would crash with a `UNIQUE constraint failed: job_postings.title, job_postings.company_id` error. The duplicate-detection logic skipped the title+company_id check when the company didn't yet exist at check time, allowing a second search run (or concurrent request) to attempt inserting a posting that was already in the DB.

This adds a final existence check after the company is resolved but before the new `JobPosting` is created. If a matching posting already exists, it's linked as a `SearchResult` (is_new=False) instead of triggering a constraint violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)