### PR TITLE
feat: add inline auto-saving tier selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .env
 .superpowers/
 .worktrees/
+backups/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+DB = backend/runway.db
+BACKUP_DIR = backups
+TIMESTAMP = $(shell date +%Y%m%d-%H%M%S)
+
+backup:
+	mkdir -p $(BACKUP_DIR)
+	sqlite3 $(DB) ".backup '$(BACKUP_DIR)/runway-$(TIMESTAMP).db'"
+	@echo "Backup saved to $(BACKUP_DIR)/runway-$(TIMESTAMP).db"

--- a/frontend/src/lib/components/PipelineDetailPanel.svelte
+++ b/frontend/src/lib/components/PipelineDetailPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { PipelineEntry, PipelineHistory, InterviewNote } from '$lib/types';
-	import { pipeline, interviews } from '$lib/api';
+	import { pipeline, interviews, postings } from '$lib/api';
 	import { onMount } from 'svelte';
 
 	interface Props {
@@ -23,6 +23,7 @@
 	let next_action_date = $state(
 		entry.next_action_date ? entry.next_action_date.substring(0, 10) : ''
 	);
+	let tier = $state<number | null>(entry.job_posting.tier ?? null);
 
 	// New interview form
 	let showInterviewForm = $state(false);
@@ -132,6 +133,16 @@
 						</div>
 					</div>
 				{/if}
+
+				<div class="section">
+					<h3>Tier</h3>
+					<select bind:value={tier} style="width: 120px" onchange={() => postings.update(entry.job_posting.id, { tier })}>
+						<option value={null}>None</option>
+						<option value={1}>Tier 1</option>
+						<option value={2}>Tier 2</option>
+						<option value={3}>Tier 3</option>
+					</select>
+				</div>
 
 				<div class="section">
 					<h3>Notes</h3>

--- a/frontend/src/lib/components/PostingDetailPanel.svelte
+++ b/frontend/src/lib/components/PostingDetailPanel.svelte
@@ -69,7 +69,6 @@
 				salary_max: editSalaryMax ?? null,
 				url: editUrl || null,
 				description: editDescription || null,
-				tier: editTier,
 			});
 			localPosting = updated;
 			editing = false;
@@ -181,20 +180,9 @@
 						<input type="number" bind:value={editSalaryMax} style="width: 100%" />
 					</div>
 				</div>
-				<div class="form-row">
-					<div class="form-group">
-						<label>URL</label>
-						<input type="url" bind:value={editUrl} style="width: 100%" />
-					</div>
-					<div class="form-group" style="flex: 0 0 auto; width: 110px">
-						<label>Tier</label>
-						<select bind:value={editTier} style="width: 100%">
-							<option value={null}>None</option>
-							<option value={1}>Tier 1</option>
-							<option value={2}>Tier 2</option>
-							<option value={3}>Tier 3</option>
-						</select>
-					</div>
+				<div class="form-group">
+					<label>URL</label>
+					<input type="url" bind:value={editUrl} style="width: 100%" />
 				</div>
 				<div class="form-group">
 					<label>Description</label>
@@ -212,9 +200,22 @@
 			</div>
 		{:else}
 			<div class="panel-meta">
-				{#if localPosting.tier}
-					<span class="badge tier-badge tier-{localPosting.tier}">Tier {localPosting.tier}</span>
-				{/if}
+				<select
+					class="tier-select"
+					value={localPosting.tier ?? ''}
+					onchange={async (e) => {
+						const val = (e.target as HTMLSelectElement).value;
+						const newTier = val === '' ? null : Number(val);
+						const updated = await postings.update(localPosting.id, { tier: newTier });
+						localPosting = updated;
+						onUpdated();
+					}}
+				>
+					<option value="">No tier</option>
+					<option value={1}>Tier 1</option>
+					<option value={2}>Tier 2</option>
+					<option value={3}>Tier 3</option>
+				</select>
 				{#if localPosting.location}
 					<span class="meta-item">📍 {localPosting.location}</span>
 				{/if}
@@ -493,6 +494,16 @@
 		gap: 0.5rem;
 		margin-top: auto;
 		padding-top: 1rem;
+	}
+
+	.tier-select {
+		font-size: 0.85rem;
+		padding: 0.15rem 0.35rem;
+		border-radius: var(--radius);
+		border: 1px solid var(--border-color);
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+		width: auto;
 	}
 
 	.tier-badge {

--- a/frontend/src/routes/postings/+page.svelte
+++ b/frontend/src/routes/postings/+page.svelte
@@ -98,6 +98,15 @@
 		await loadPostings();
 	}
 
+	async function setTier(posting: JobPosting, e: Event) {
+		e.stopPropagation();
+		const val = (e.target as HTMLSelectElement).value;
+		const tier = val === '' ? null : Number(val);
+		await postingsApi.update(posting.id, { tier });
+		posting.tier = tier;
+		allPostings = allPostings; // trigger reactivity
+	}
+
 	async function deleteSelected() {
 		if (!confirm(`Delete ${selected.size} posting(s)?`)) return;
 		await Promise.all([...selected].map((id) => postingsApi.delete(id)));
@@ -228,10 +237,13 @@
 						</td>
 						<td>{posting.location ?? '-'}</td>
 						<td>{formatSalary(posting.salary_min, posting.salary_max)}</td>
-						<td>
-							{#if posting.tier}
-								<span class="badge tier-badge tier-{posting.tier}">T{posting.tier}</span>
-							{/if}
+						<td onclick={(e) => e.stopPropagation()}>
+							<select class="tier-select tier-val-{posting.tier ?? 0}" value={posting.tier ?? ''} onchange={(e) => setTier(posting, e)}>
+								<option value="">—</option>
+								<option value={1}>T1</option>
+								<option value={2}>T2</option>
+								<option value={3}>T3</option>
+							</select>
 						</td>
 						<td><span class="badge badge-stage">{posting.source}</span></td>
 						<td>
@@ -370,6 +382,20 @@
 		cursor: pointer;
 		white-space: nowrap;
 	}
+
+	.tier-select {
+		font-size: 0.8rem;
+		padding: 0.1rem 0.25rem;
+		border-radius: var(--radius);
+		border: 1px solid var(--border-color);
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+		width: 52px;
+	}
+
+	.tier-val-1 { background: color-mix(in srgb, #f59e0b 20%, transparent); color: #b45309; border-color: #f59e0b; }
+	.tier-val-2 { background: color-mix(in srgb, #6b7280 20%, transparent); color: #4b5563; border-color: #9ca3af; }
+	.tier-val-3 { background: color-mix(in srgb, #cd7c3a 20%, transparent); color: #92400e; border-color: #cd7c3a; }
 
 	.tier-badge {
 		font-weight: 700;


### PR DESCRIPTION
## Summary
- Add tier dropdown to postings table for quick tier assignment without opening detail panel
- Add auto-saving tier selector to posting detail panel (visible in view mode)
- Add auto-saving tier selector to pipeline detail panel Details tab
- Add Makefile with `make backup` target for SQLite database backups
- Exclude backups/ from git

All tier selections now save immediately on change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)