### PR TITLE
Hide empty table cells instead of showing dash

### DIFF
--- a/frontend/src/lib/components/SearchResultsTable.svelte
+++ b/frontend/src/lib/components/SearchResultsTable.svelte
@@ -25,7 +25,7 @@
 	}
 
 	function formatSalary(min: number | null, max: number | null): string {
-		if (!min && !max) return '-';
+		if (!min && !max) return '';
 		const fmt = (n: number) => '$' + n.toLocaleString();
 		if (min && max) return `${fmt(min)} - ${fmt(max)}`;
 		if (min) return `${fmt(min)}+`;
@@ -103,11 +103,11 @@
 				{#each sortedResults as posting}
 					<tr class="result-row" onclick={() => selectedPosting = posting}>
 						<td>{posting.title}</td>
-						<td>{posting.company?.name ?? '-'}</td>
-						<td>{posting.location ?? '-'}</td>
+						<td>{posting.company?.name ?? ''}</td>
+						<td>{posting.location ?? ''}</td>
 						<td>{formatSalary(posting.salary_min, posting.salary_max)}</td>
 						<td><span class="badge badge-stage">{posting.source}</span></td>
-						<td>{posting.date_posted ? new Date(posting.date_posted).toLocaleDateString() : '-'}</td>
+						<td>{posting.date_posted ? new Date(posting.date_posted).toLocaleDateString() : ''}</td>
 						<td class="actions" onclick={(e) => e.stopPropagation()}>
 							{#if onSave}
 								<button class="btn btn-sm btn-primary" onclick={() => onSave(posting)}>Save</button>

--- a/frontend/src/routes/postings/+page.svelte
+++ b/frontend/src/routes/postings/+page.svelte
@@ -121,7 +121,7 @@
 	}
 
 	function formatSalary(min: number | null, max: number | null): string {
-		if (!min && !max) return '-';
+		if (!min && !max) return '';
 		const fmt = (n: number) => '$' + Math.round(n / 1000) + 'k';
 		if (min && max) return `${fmt(min)}–${fmt(max)}`;
 		if (min) return `${fmt(min)}+`;
@@ -232,10 +232,10 @@
 									{posting.company.name}
 								</button>
 							{:else}
-								{posting.company_name ?? '-'}
+								{posting.company_name ?? ''}
 							{/if}
 						</td>
-						<td>{posting.location ?? '-'}</td>
+						<td>{posting.location ?? ''}</td>
 						<td>{formatSalary(posting.salary_min, posting.salary_max)}</td>
 						<td onclick={(e) => e.stopPropagation()}>
 							<select class="tier-select tier-val-{posting.tier ?? 0}" value={posting.tier ?? ''} onchange={(e) => setTier(posting, e)}>


### PR DESCRIPTION
## Summary
- Table cells with no value previously displayed a `-` placeholder
- Empty company, location, salary, and date fields now show nothing instead
- Affects both the search results table and the saved/dismissed postings table