### PR TITLE
fix: hide add to pipeline button immediately after successful add

### DIFF
--- a/frontend/src/lib/components/PostingDetailPanel.svelte
+++ b/frontend/src/lib/components/PostingDetailPanel.svelte
@@ -116,7 +116,8 @@
 	async function handleAddToPipeline() {
 		addingToPipeline = true;
 		try {
-			await pipeline.add({ job_posting_id: posting.id });
+			const entry = await pipeline.add({ job_posting_id: posting.id });
+			localPosting = { ...localPosting, pipeline_stage: entry.stage };
 			status = 'Added to pipeline!';
 			onUpdated();
 		} catch (e) {


### PR DESCRIPTION
After adding a job posting to a pipeline, the "+ Add to Pipeline" button remained visible in `PostingDetailPanel`. The button visibility was controlled by `!localPosting.pipeline_stage`, but that field was never updated locally after the API call succeeded.

This fix captures the returned `PipelineEntry` from `pipeline.add()` and immediately updates `localPosting.pipeline_stage`, so the button disappears right away without waiting for the parent to re-render.