### PR TITLE
fix: correct summarize_posting system prompt to request markdown not JSON

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -81,8 +81,8 @@ def summarize_posting(raw_content: str) -> str:
         kwargs["api_base"] = OLLAMA_BASE_URL
 
     system_prompt = (
-        "You are a job posting parser. Extract structured information from the raw job posting text "
-        "and return valid JSON only — no explanation, no markdown fences, no surrounding text."
+        "You are a job posting summarizer. Write clean, well-structured markdown summaries of job postings. "
+        "Return only markdown — no JSON, no explanation, no surrounding text."
     )
 
     user_prompt = (


### PR DESCRIPTION
## Summary

- The `summarize_posting` system prompt incorrectly said "return valid JSON only", which caused the model to return JSON instead of markdown
- Fixes the system prompt to align with what the user prompt already requests

## Test Plan

- [ ] Click "Generate Summary" on a posting with raw content → description renders as formatted markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)