### PR TITLE
fix: handle NaN company name from jobspy to prevent NOT NULL violation

### DIFF
--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -24,7 +24,7 @@ def run_search(profile: SearchProfile, db: Session) -> dict:
     for _, row in df.iterrows():
         url = row.get("job_url")
         title = row.get("title", "Unknown")
-        company_name = row.get("company", "Unknown")
+        company_name = _to_str(row.get("company")) or "Unknown"
 
         # Salary filter: when min salary is set, require salary data that meets the threshold
         if profile.salary_min is not None:


### PR DESCRIPTION
## Summary
- Search was crashing with `IntegrityError: NOT NULL constraint failed: companies.name`
- `row.get("company", "Unknown")` doesn't use the default when the key exists with a pandas `NaN` value, passing `NULL` to SQLite
- Fixed by using the existing `_to_str()` helper (which handles `NaN`) with an `or "Unknown"` fallback

## Test Plan
- [ ] Run a search and verify it completes without 500 error when results have missing company names
- [ ] `cd backend && pytest` — all 50 tests pass