### PR TITLE
fix: individual row selection in postings table

### DIFF
--- a/frontend/src/routes/postings/+page.svelte
+++ b/frontend/src/routes/postings/+page.svelte
@@ -228,7 +228,7 @@
 						class:row-selected={selected.has(posting.id)}
 						onclick={() => (selectedPosting = posting)}
 					>
-						<td onclick={(e) => { e.stopPropagation(); toggleSelect(posting.id); }}>
+						<td onclick={(e) => e.stopPropagation()}>
 							<input type="checkbox" checked={selected.has(posting.id)} onchange={() => toggleSelect(posting.id)} />
 						</td>
 						<td>{posting.title}</td>


### PR DESCRIPTION
Clicking individual row checkboxes had no effect because the `<td>` onclick handler called `toggleSelect()` in addition to the checkbox's own `onchange` handler — the double-call cancelled out the selection. Removed `toggleSelect` from the `<td>` onclick, leaving only `e.stopPropagation()` to prevent the row-click from opening the detail panel.