### PR TITLE
feat: pipeline filters under heading with company/description search

### DIFF
--- a/frontend/src/lib/components/KanbanBoard.svelte
+++ b/frontend/src/lib/components/KanbanBoard.svelte
@@ -18,11 +18,12 @@
 	interface Props {
 		board: Record<string, PipelineEntry[]>;
 		tierFilter: number | null;
+		searchFilter: string;
 		onCardClick: (entry: PipelineEntry) => void;
 		onMoved: () => void;
 	}
 
-	let { board, tierFilter, onCardClick, onMoved }: Props = $props();
+	let { board, tierFilter, searchFilter, onCardClick, onMoved }: Props = $props();
 
 	let draggingEntryId = $state<number | null>(null);
 	let dragOverStage = $state<string | null>(null);
@@ -61,7 +62,16 @@
 
 <div class="kanban-board">
 	{#each STAGES as stage}
-		{@const entries = (board[stage.key] ?? []).filter((e) => tierFilter === null || e.job_posting.tier === tierFilter)}
+		{@const entries = (board[stage.key] ?? [])
+			.filter((e) => tierFilter === null || e.job_posting.tier === tierFilter)
+			.filter((e) => {
+				if (!searchFilter) return true;
+				const q = searchFilter.toLowerCase();
+				return (
+					e.job_posting.company_name?.toLowerCase().includes(q) ||
+					e.job_posting.description?.toLowerCase().includes(q)
+				);
+			})}
 		<div
 			class="kanban-column"
 			class:drag-over={dragOverStage === stage.key}

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { tierFilter, searchFilter } from '$lib/stores/pipelineFilters';
 
 	const navItems = [
 		{ href: '/search', label: 'Search' },
@@ -7,6 +8,8 @@
 		{ href: '/postings', label: 'Saved Postings' },
 		{ href: '/companies', label: 'Companies' },
 	];
+
+	$: onPipeline = page.url.pathname.startsWith('/pipeline');
 </script>
 
 <aside class="sidebar">
@@ -20,6 +23,38 @@
 			>
 				{item.label}
 			</a>
+			{#if item.href === '/pipeline' && onPipeline}
+				<div class="pipeline-filters">
+					<input
+						class="filter-search"
+						type="text"
+						placeholder="Search…"
+						bind:value={$searchFilter}
+					/>
+					<div class="tier-btns">
+						<button
+							class="tier-btn"
+							class:tier-btn-all-active={$tierFilter === null}
+							onclick={() => ($tierFilter = null)}
+						>All</button>
+						<button
+							class="tier-btn tier-btn-1"
+							class:active={$tierFilter === 1}
+							onclick={() => ($tierFilter = $tierFilter === 1 ? null : 1)}
+						>T1</button>
+						<button
+							class="tier-btn tier-btn-2"
+							class:active={$tierFilter === 2}
+							onclick={() => ($tierFilter = $tierFilter === 2 ? null : 2)}
+						>T2</button>
+						<button
+							class="tier-btn tier-btn-3"
+							class:active={$tierFilter === 3}
+							onclick={() => ($tierFilter = $tierFilter === 3 ? null : 3)}
+						>T3</button>
+					</div>
+				</div>
+			{/if}
 		{/each}
 	</nav>
 </aside>
@@ -73,5 +108,75 @@
 	.nav-link.active {
 		background: var(--bg-tertiary);
 		color: var(--accent-blue);
+	}
+
+	.pipeline-filters {
+		padding: 0.5rem 0.5rem 0.25rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.filter-search {
+		width: 100%;
+		box-sizing: border-box;
+		padding: 0.35rem 0.5rem;
+		font-size: 0.8rem;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		outline: none;
+	}
+
+	.filter-search:focus {
+		border-color: var(--accent-blue);
+	}
+
+	.tier-btns {
+		display: flex;
+		gap: 0.3rem;
+	}
+
+	.tier-btn {
+		flex: 1;
+		padding: 0.25rem 0;
+		font-size: 0.75rem;
+		font-weight: 600;
+		border-radius: var(--radius);
+		border: 1px solid var(--border-color);
+		background: var(--bg-tertiary);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s, border-color 0.15s;
+	}
+
+	.tier-btn:hover {
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+	}
+
+	.tier-btn-all-active {
+		background: var(--accent-blue);
+		color: #fff;
+		border-color: var(--accent-blue);
+	}
+
+	.tier-btn-1.active {
+		background: color-mix(in srgb, #f59e0b 30%, transparent);
+		color: #b45309;
+		border-color: #f59e0b;
+	}
+
+	.tier-btn-2.active {
+		background: color-mix(in srgb, #6b7280 30%, transparent);
+		color: #374151;
+		border-color: #9ca3af;
+	}
+
+	.tier-btn-3.active {
+		background: color-mix(in srgb, #cd7c3a 30%, transparent);
+		color: #92400e;
+		border-color: #cd7c3a;
 	}
 </style>

--- a/frontend/src/lib/stores/pipelineFilters.ts
+++ b/frontend/src/lib/stores/pipelineFilters.ts
@@ -1,0 +1,4 @@
+import { writable } from 'svelte/store';
+
+export const tierFilter = writable<number | null>(null);
+export const searchFilter = writable<string>('');

--- a/frontend/src/routes/pipeline/+page.svelte
+++ b/frontend/src/routes/pipeline/+page.svelte
@@ -3,11 +3,11 @@
 	import { pipeline } from '$lib/api';
 	import KanbanBoard from '$lib/components/KanbanBoard.svelte';
 	import PipelineDetailPanel from '$lib/components/PipelineDetailPanel.svelte';
+	import { tierFilter, searchFilter } from '$lib/stores/pipelineFilters';
 	import { onMount } from 'svelte';
 
 	let board = $state<Record<string, PipelineEntry[]>>({});
 	let selectedEntry = $state<PipelineEntry | null>(null);
-	let tierFilter = $state<number | null>(null);
 
 	onMount(loadBoard);
 
@@ -35,43 +35,8 @@
 	}
 </script>
 
-<div class="page-header">
-	<h1>Pipeline</h1>
-	<div class="tier-filter">
-		<button class="btn btn-sm" class:btn-primary={tierFilter === null} class:btn-secondary={tierFilter !== null} onclick={() => (tierFilter = null)}>All</button>
-		<button class="btn btn-sm tier-btn-1" class:active={tierFilter === 1} onclick={() => (tierFilter = tierFilter === 1 ? null : 1)}>T1</button>
-		<button class="btn btn-sm tier-btn-2" class:active={tierFilter === 2} onclick={() => (tierFilter = tierFilter === 2 ? null : 2)}>T2</button>
-		<button class="btn btn-sm tier-btn-3" class:active={tierFilter === 3} onclick={() => (tierFilter = tierFilter === 3 ? null : 3)}>T3</button>
-	</div>
-</div>
+<KanbanBoard {board} tierFilter={$tierFilter} searchFilter={$searchFilter} onCardClick={handleCardClick} onMoved={handleMoved} />
 
-<KanbanBoard {board} {tierFilter} onCardClick={handleCardClick} onMoved={handleMoved} />
-
-<style>
-	.tier-filter {
-		display: flex;
-		gap: 0.4rem;
-		align-items: center;
-	}
-
-	.tier-btn-1.active {
-		background: color-mix(in srgb, #f59e0b 30%, transparent);
-		color: #b45309;
-		border-color: #f59e0b;
-	}
-
-	.tier-btn-2.active {
-		background: color-mix(in srgb, #6b7280 30%, transparent);
-		color: #374151;
-		border-color: #9ca3af;
-	}
-
-	.tier-btn-3.active {
-		background: color-mix(in srgb, #cd7c3a 30%, transparent);
-		color: #92400e;
-		border-color: #cd7c3a;
-	}
-</style>
 
 {#if selectedEntry}
 	<PipelineDetailPanel


### PR DESCRIPTION
Adds a search input and tier filter buttons (All, T1, T2, T3) below the Pipeline heading on the pipeline page. The search filters kanban cards by company name or job description. Removes the page-level `<h1>Pipeline</h1>` row in favor of a stacked layout with filters directly underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)