### PR TITLE
feat: Ctrl+Enter keyboard shortcut to save notes

### DIFF
--- a/frontend/src/lib/components/CompanyDetail.svelte
+++ b/frontend/src/lib/components/CompanyDetail.svelte
@@ -176,7 +176,7 @@
 
 			<div class="section">
 				<h3>Notes</h3>
-				<textarea bind:value={notes} rows={4} style="width:100%" placeholder="Notes about this company..."></textarea>
+				<textarea bind:value={notes} rows={4} style="width:100%" placeholder="Notes about this company..." onkeydown={(e) => { if (e.ctrlKey && e.key === 'Enter') saveNotes(); }}></textarea>
 				<button class="btn btn-sm btn-secondary" onclick={saveNotes} disabled={savingNotes} style="margin-top:0.4rem">
 					{savingNotes ? 'Saving...' : 'Save Notes'}
 				</button>

--- a/frontend/src/lib/components/PipelineDetailPanel.svelte
+++ b/frontend/src/lib/components/PipelineDetailPanel.svelte
@@ -146,7 +146,7 @@
 
 				<div class="section">
 					<h3>Notes</h3>
-					<textarea bind:value={notes} rows={4} style="width: 100%" placeholder="Application notes..."></textarea>
+					<textarea bind:value={notes} rows={4} style="width: 100%" placeholder="Application notes..." onkeydown={(e) => { if (e.ctrlKey && e.key === 'Enter') saveDetails(); }}></textarea>
 				</div>
 
 				<div class="section">
@@ -195,7 +195,7 @@
 						</div>
 						<div class="form-group">
 							<label>Notes</label>
-							<textarea bind:value={iNotes} rows={3} style="width:100%"></textarea>
+							<textarea bind:value={iNotes} rows={3} style="width:100%" onkeydown={(e) => { if (e.ctrlKey && e.key === 'Enter' && iRound) addInterview(); }}></textarea>
 						</div>
 						<div class="form-group">
 							<label>Outcome</label>

--- a/frontend/src/lib/components/PostingDetailPanel.svelte
+++ b/frontend/src/lib/components/PostingDetailPanel.svelte
@@ -201,7 +201,7 @@
 				</div>
 				<div class="form-group">
 					<label>Description</label>
-					<textarea bind:value={editDescription} rows={8} style="width: 100%"></textarea>
+					<textarea bind:value={editDescription} rows={8} style="width: 100%" onkeydown={(e) => { if (e.ctrlKey && e.key === 'Enter' && editTitle) handleSave(); }}></textarea>
 				</div>
 				{#if status}
 					<p class="status-msg error">{status}</p>


### PR DESCRIPTION
Adds Ctrl+Enter as a keyboard shortcut to save notes/comments across the app, so you don't have to reach for the mouse. The shortcut is wired up on all notes textareas: pipeline application notes, pipeline interview notes (requires Round to be filled), company notes, and posting description (edit mode).