### PR TITLE
fix: change T3 tier badge color from brown to blue

### DIFF
--- a/frontend/src/lib/components/KanbanCard.svelte
+++ b/frontend/src/lib/components/KanbanCard.svelte
@@ -115,9 +115,9 @@
 	}
 
 	.tier-3 {
-		background: color-mix(in srgb, #cd7c3a 25%, transparent);
-		color: #92400e;
-		border: 1px solid #cd7c3a;
+		background: color-mix(in srgb, #3b82f6 25%, transparent);
+		color: #1d4ed8;
+		border: 1px solid #3b82f6;
 	}
 
 	.card-company {

--- a/frontend/src/lib/components/PostingDetailPanel.svelte
+++ b/frontend/src/lib/components/PostingDetailPanel.svelte
@@ -546,8 +546,8 @@
 	}
 
 	.tier-3 {
-		background: color-mix(in srgb, #cd7c3a 20%, transparent);
-		color: #92400e;
-		border: 1px solid #cd7c3a;
+		background: color-mix(in srgb, #3b82f6 20%, transparent);
+		color: #1d4ed8;
+		border: 1px solid #3b82f6;
 	}
 </style>


### PR DESCRIPTION
T1 (amber) and T3 (brown/copper) tier badges were too visually similar on the pipeline/kanban screen. T3 is now blue (`#3b82f6`) to make all three tiers clearly distinguishable at a glance. Updated in both `KanbanCard.svelte` and `PostingDetailPanel.svelte`.