### PR TITLE
fix: replace legacy $: with $derived in Sidebar

### DIFF
--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -9,7 +9,7 @@
 		{ href: '/companies', label: 'Companies' },
 	];
 
-	$: onPipeline = page.url.pathname.startsWith('/pipeline');
+	const onPipeline = $derived(page.url.pathname.startsWith('/pipeline'));
 </script>
 
 <aside class="sidebar">


### PR DESCRIPTION
Fixes a compile error in Svelte 5 runes mode where the legacy `$:` reactive statement is not allowed. Replaces it with `$derived()`.