### PR TITLE
fix: prevent company name from wrapping in postings table

### DIFF
--- a/frontend/src/routes/postings/+page.svelte
+++ b/frontend/src/routes/postings/+page.svelte
@@ -331,6 +331,7 @@
 		font-size: inherit;
 		font-family: inherit;
 		text-decoration: none;
+		white-space: nowrap;
 	}
 
 	.company-link:hover {


### PR DESCRIPTION
Adds `white-space: nowrap` to the `.company-link` button in the postings table so long company names like "Zions Bancorporation" stay on a single line instead of wrapping awkwardly across two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)