### PR TITLE
fix: swap T2 and T3 tier badge colors

### DIFF
--- a/frontend/src/lib/components/KanbanCard.svelte
+++ b/frontend/src/lib/components/KanbanCard.svelte
@@ -109,15 +109,15 @@
 	}
 
 	.tier-2 {
-		background: color-mix(in srgb, #6b7280 25%, transparent);
-		color: #4b5563;
-		border: 1px solid #9ca3af;
-	}
-
-	.tier-3 {
 		background: color-mix(in srgb, #3b82f6 25%, transparent);
 		color: #1d4ed8;
 		border: 1px solid #3b82f6;
+	}
+
+	.tier-3 {
+		background: color-mix(in srgb, #6b7280 25%, transparent);
+		color: #4b5563;
+		border: 1px solid #9ca3af;
 	}
 
 	.card-company {

--- a/frontend/src/lib/components/PostingDetailPanel.svelte
+++ b/frontend/src/lib/components/PostingDetailPanel.svelte
@@ -540,14 +540,14 @@
 	}
 
 	.tier-2 {
-		background: color-mix(in srgb, #6b7280 20%, transparent);
-		color: #4b5563;
-		border: 1px solid #9ca3af;
-	}
-
-	.tier-3 {
 		background: color-mix(in srgb, #3b82f6 20%, transparent);
 		color: #1d4ed8;
 		border: 1px solid #3b82f6;
+	}
+
+	.tier-3 {
+		background: color-mix(in srgb, #6b7280 20%, transparent);
+		color: #4b5563;
+		border: 1px solid #9ca3af;
 	}
 </style>

--- a/frontend/src/routes/pipeline/+page.svelte
+++ b/frontend/src/routes/pipeline/+page.svelte
@@ -107,15 +107,15 @@
 	}
 
 	.tier-btn-2.active {
-		background: color-mix(in srgb, #6b7280 30%, transparent);
-		color: #374151;
-		border-color: #9ca3af;
-	}
-
-	.tier-btn-3.active {
 		background: color-mix(in srgb, #cd7c3a 30%, transparent);
 		color: #92400e;
 		border-color: #cd7c3a;
+	}
+
+	.tier-btn-3.active {
+		background: color-mix(in srgb, #6b7280 30%, transparent);
+		color: #374151;
+		border-color: #9ca3af;
 	}
 </style>
 

--- a/frontend/src/routes/postings/+page.svelte
+++ b/frontend/src/routes/postings/+page.svelte
@@ -401,8 +401,8 @@
 	}
 
 	.tier-val-1 { background: color-mix(in srgb, #f59e0b 20%, transparent); color: #b45309; border-color: #f59e0b; }
-	.tier-val-2 { background: color-mix(in srgb, #6b7280 20%, transparent); color: #4b5563; border-color: #9ca3af; }
-	.tier-val-3 { background: color-mix(in srgb, #cd7c3a 20%, transparent); color: #92400e; border-color: #cd7c3a; }
+	.tier-val-2 { background: color-mix(in srgb, #cd7c3a 20%, transparent); color: #92400e; border-color: #cd7c3a; }
+	.tier-val-3 { background: color-mix(in srgb, #6b7280 20%, transparent); color: #4b5563; border-color: #9ca3af; }
 
 	.tier-badge {
 		font-weight: 700;
@@ -416,14 +416,14 @@
 	}
 
 	.tier-2 {
-		background: color-mix(in srgb, #6b7280 20%, transparent);
-		color: #4b5563;
-		border: 1px solid #9ca3af;
-	}
-
-	.tier-3 {
 		background: color-mix(in srgb, #cd7c3a 20%, transparent);
 		color: #92400e;
 		border: 1px solid #cd7c3a;
+	}
+
+	.tier-3 {
+		background: color-mix(in srgb, #6b7280 20%, transparent);
+		color: #4b5563;
+		border: 1px solid #9ca3af;
 	}
 </style>


### PR DESCRIPTION
Swaps the display colors for T2 and T3 tier badges across all relevant components: the postings table, pipeline filter buttons, posting detail panel, and kanban cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)