### PR TITLE
feat: add justfile with migrate, dev, and backup recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+migrate:
+    cd backend && .venv/bin/alembic upgrade head
+
+dev:
+    ./run.sh
+
+backup:
+    mkdir -p backups
+    sqlite3 backend/runway.db ".backup 'backups/runway-$(date +%Y%m%d-%H%M%S).db'"
+    @echo "Backup saved."


### PR DESCRIPTION
## Summary
- Adds a `justfile` with three recipes: `just migrate` (runs Alembic migrations via the backend venv), `just dev` (starts the app), and `just backup` (creates a timestamped SQLite backup).
- Consolidates the existing `Makefile` backup target and `run.sh` under a single `just` interface.
- Motivated by `alembic` not being on `$PATH` — `just migrate` now uses `backend/.venv/bin/alembic` directly.

## Test Plan
- [ ] `just migrate` runs without error (`alembic upgrade head`)
- [ ] `just backup` creates a file in `backups/`
- [ ] `just dev` starts backend and frontend as before