### PR TITLE
Move saved postings above search in sidebar

### DIFF
--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -4,8 +4,8 @@
 	const navItems = [
 		{ href: '/dashboard', label: 'Dashboard', exact: true },
 		{ href: '/pipeline', label: 'Pipeline' },
-		{ href: '/search', label: 'Search' },
 		{ href: '/postings', label: 'Saved Postings' },
+		{ href: '/search', label: 'Search' },
 		{ href: '/companies', label: 'Companies' },
 	];
 </script>


### PR DESCRIPTION
Reorders the sidebar navigation so that Saved Postings appears above Search.