### PR TITLE
feat: add Withdrawn kanban column and auto rejected_date

### DIFF
--- a/backend/alembic/versions/e1c7761e3577_add_rejected_date_to_pipeline_entries.py
+++ b/backend/alembic/versions/e1c7761e3577_add_rejected_date_to_pipeline_entries.py
@@ -1,0 +1,28 @@
+"""add rejected_date to pipeline_entries
+
+Revision ID: e1c7761e3577
+Revises: a2eab2b0eed2
+Create Date: 2026-04-10 21:55:05.354931
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e1c7761e3577'
+down_revision: Union[str, Sequence[str], None] = 'a2eab2b0eed2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('pipeline_entries', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('rejected_date', sa.Date(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('pipeline_entries', schema=None) as batch_op:
+        batch_op.drop_column('rejected_date')

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -12,6 +12,7 @@ STAGES = [
     "onsite_completed",
     "offer",
     "rejected",
+    "withdrawn",
     "archived",
 ]
 
@@ -31,6 +32,7 @@ STAGE_GROUPS = {
     "onsite_completed": "Onsite",
     "offer": "Offer",
     "rejected": "Rejected",
+    "withdrawn": "Withdrawn",
     "archived": "Archived",
 }
 
@@ -53,5 +55,6 @@ STAGE_GROUP_ORDER = [
     "Onsite",
     "Offer",
     "Rejected",
+    "Withdrawn",
     "Archived",
 ]

--- a/backend/app/models/pipeline.py
+++ b/backend/app/models/pipeline.py
@@ -21,6 +21,7 @@ class PipelineEntry(Base):
     onsite_date: Mapped[date | None] = mapped_column(Date)
     offer_date: Mapped[date | None] = mapped_column(Date)
     offer_expiration_date: Mapped[date | None] = mapped_column(Date)
+    rejected_date: Mapped[date | None] = mapped_column(Date)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
 

--- a/backend/app/routers/pipeline.py
+++ b/backend/app/routers/pipeline.py
@@ -98,7 +98,8 @@ def move_pipeline_entry(entry_id: int, data: PipelineMoveRequest, db: Session = 
     entry.stage = data.to_stage
     if data.stage_dates:
         valid_date_fields = {"applied_date", "recruiter_screen_date", "manager_screen_date",
-                             "tech_screen_date", "onsite_date", "offer_date", "offer_expiration_date"}
+                             "tech_screen_date", "onsite_date", "offer_date", "offer_expiration_date",
+                             "rejected_date"}
         for field, value in data.stage_dates.items():
             if field in valid_date_fields:
                 setattr(entry, field, value)

--- a/backend/app/schemas/pipeline.py
+++ b/backend/app/schemas/pipeline.py
@@ -38,6 +38,7 @@ class PipelineEntryUpdate(BaseModel):
     onsite_date: Optional[FlexDate] = None
     offer_date: Optional[FlexDate] = None
     offer_expiration_date: Optional[FlexDate] = None
+    rejected_date: Optional[FlexDate] = None
 
 
 class PipelineMoveRequest(BaseModel):
@@ -84,6 +85,7 @@ class PipelineEntryRead(BaseModel):
     onsite_date: Optional[Date] = None
     offer_date: Optional[Date] = None
     offer_expiration_date: Optional[Date] = None
+    rejected_date: Optional[Date] = None
     custom_dates: list[CustomDateRead] = []
     created_at: datetime
     updated_at: datetime

--- a/backend/tests/test_constants.py
+++ b/backend/tests/test_constants.py
@@ -52,11 +52,11 @@ def test_stage_group_order_contains_all_unique_groups():
     assert len(STAGE_GROUP_ORDER) == len(unique_groups)
 
 
-def test_stage_group_order_has_nine_groups():
-    """There should be exactly 9 display groups."""
+def test_stage_group_order_has_eleven_groups():
+    """There should be exactly 11 display groups."""
     from app.constants import STAGE_GROUP_ORDER
 
-    assert len(STAGE_GROUP_ORDER) == 10
+    assert len(STAGE_GROUP_ORDER) == 11
 
 
 def test_stage_group_order_preserves_pipeline_order():
@@ -73,6 +73,7 @@ def test_stage_group_order_preserves_pipeline_order():
         "Onsite",
         "Offer",
         "Rejected",
+        "Withdrawn",
         "Archived",
     ]
     assert STAGE_GROUP_ORDER == expected

--- a/frontend/src/lib/pipeline.ts
+++ b/frontend/src/lib/pipeline.ts
@@ -42,6 +42,7 @@ export const STAGES: StageConfig[] = [
 	},
 	{ key: 'offer', label: 'Offer' },
 	{ key: 'rejected', label: 'Rejected' },
+	{ key: 'withdrawn', label: 'Withdrawn' },
 	{ key: 'archived', label: 'Archived' },
 ];
 
@@ -57,11 +58,13 @@ export const STAGE_DATE_FIELDS: Record<string, { label: string; field: string }[
 	],
 };
 
-export const AUTO_DATE_STAGES: Record<string, string> = {};
+export const AUTO_DATE_STAGES: Record<string, string> = {
+	rejected: 'rejected_date',
+};
 
 export const ACTIVE_STAGES = STAGES.filter(
-	(s) => s.key !== 'rejected' && s.key !== 'archived'
+	(s) => s.key !== 'rejected' && s.key !== 'withdrawn' && s.key !== 'archived'
 );
 export const TERMINAL_STAGES = STAGES.filter(
-	(s) => s.key === 'rejected' || s.key === 'archived'
+	(s) => s.key === 'rejected' || s.key === 'withdrawn' || s.key === 'archived'
 );


### PR DESCRIPTION
## Summary
- Adds a **Withdrawn** terminal kanban column (between Rejected and Archived) for jobs you've stopped pursuing
- Adds a `rejected_date` field that auto-fills to today's date when a card is dragged to Rejected — no modal prompt
- Updates backend constants, model, schema, router, Alembic migration, and frontend stage config

## Test Plan
- [ ] Navigate to Pipeline page — confirm Withdrawn column appears between Rejected and Archived
- [ ] Drag a card to Withdrawn — confirm it moves and persists after refresh
- [ ] Drag a card to Rejected — confirm it moves immediately (no date modal) and `rejected_date` is set to today in the card detail view