### PR TITLE
Remove Companies from sidebar navigation

### DIFF
--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -6,7 +6,6 @@
 		{ href: '/pipeline', label: 'Pipeline' },
 		{ href: '/postings', label: 'Saved Jobs' },
 		{ href: '/search', label: 'Add Jobs' },
-		{ href: '/companies', label: 'Companies' },
 	];
 </script>
 


### PR DESCRIPTION
Removes the Companies link from the left-hand sidebar nav. The `/companies` route remains accessible directly but is no longer surfaced in the menu.